### PR TITLE
search-room-laptop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,4 @@ pip-selfcheck.json
 
 # Project specific
 logs/
+beliefs/

--- a/agents1/OfficialAgent.py
+++ b/agents1/OfficialAgent.py
@@ -838,7 +838,6 @@ class BaselineAgent(ArtificialBrain):
         '''
         process incoming messages received from the team members
         '''
-        print(trustBeliefs)
         receivedMessages = {}
         # Create a dictionary with a list of received messages from each team member
         for member in teamMembers:
@@ -854,8 +853,14 @@ class BaselineAgent(ArtificialBrain):
                 if msg.startswith("Search:"):
                     area = 'area ' + msg.split()[-1]
                     ## TODO and check if we trust the teammember, maybe new list??
-                    if area not in self._searched_rooms:
+                    if area not in self._searched_rooms and trustBeliefs[teamMembers[0]]['search_room_comp'] >= 0 and trustBeliefs[teamMembers[0]]['search_room_will'] >= 0:
                         self._searched_rooms.append(area)
+                    elif trustBeliefs[teamMembers[0]]['search_room_comp'] < 0:
+                        self._send_message("Did not add room to searched rooms since your competence is: {}".format(trustBeliefs[teamMembers[0]]['search_room_comp']), 'RescueBot')
+                    elif trustBeliefs[teamMembers[0]]['search_room_will'] < 0:
+                        self._send_message("Did not add room to searched rooms since your willingness is: {}".format(trustBeliefs[teamMembers[0]]['search_room_will']), 'RescueBot')
+
+
                 # If a received message involves team members finding victims, add these victims and their locations to memory
                 if msg.startswith("Found:"):
                     # Identify which victim and area it concerns

--- a/agents1/OfficialAgent.py
+++ b/agents1/OfficialAgent.py
@@ -879,7 +879,6 @@ class BaselineAgent(ArtificialBrain):
                 # If a received message involves team members searching areas, add these areas to the memory of areas that have been explored
                 if msg.startswith("Search:"):
                     area = 'area ' + msg.split()[-1]
-                    ## TODO and check if we trust the teammember, maybe new list??
                     if area not in self._searched_rooms and trustBeliefs[teamMembers[0]]['search_room_comp'] >= 0 and trustBeliefs[teamMembers[0]]['search_room_will'] >= 0:
                         self._searched_rooms.append(area)
                         self._send_message(random.choice(search_room_good_messages), 'RescueBot')

--- a/agents1/OfficialAgent.py
+++ b/agents1/OfficialAgent.py
@@ -851,6 +851,7 @@ class BaselineAgent(ArtificialBrain):
                 # If a received message involves team members searching areas, add these areas to the memory of areas that have been explored
                 if msg.startswith("Search:"):
                     area = 'area ' + msg.split()[-1]
+                    ## TODO and check if we trust the teammember, maybe new list??
                     if area not in self._searched_rooms:
                         self._searched_rooms.append(area)
                 # If a received message involves team members finding victims, add these victims and their locations to memory

--- a/agents1/OfficialAgent.py
+++ b/agents1/OfficialAgent.py
@@ -95,10 +95,12 @@ class BaselineAgent(ArtificialBrain):
             for member in self._team_members:
                 if mssg.from_id == member and mssg.content not in self._received_messages:
                     self._received_messages.append(mssg.content)
-        # Process messages from team members
-        self._process_messages(state, self._team_members, self._condition)
-        # Initialize and update trust beliefs for team members
+
         trustBeliefs = self._loadBelief(self._team_members, self._folder)
+
+        # Process messages from team members
+        self._process_messages(state, self._team_members, self._condition, trustBeliefs)
+        # Initialize and update trust beliefs for team members
         self._trustBelief(self._team_members, trustBeliefs, self._folder, self._received_messages)
 
         # Check whether human is close in distance
@@ -832,11 +834,11 @@ class BaselineAgent(ArtificialBrain):
                 zones.append(place)
         return zones
 
-    def _process_messages(self, state, teamMembers, condition):
+    def _process_messages(self, state, teamMembers, condition, trustBeliefs):
         '''
         process incoming messages received from the team members
         '''
-
+        print(trustBeliefs)
         receivedMessages = {}
         # Create a dictionary with a list of received messages from each team member
         for member in teamMembers:

--- a/beliefs/currentTrustBelief.csv
+++ b/beliefs/currentTrustBelief.csv
@@ -1,2 +1,2 @@
 name;search_room_comp;search_room_will;obstacle_removal_comp;obstacle_removal_will;search_info_comp;search_info_will;rescue_together_comp;rescue_together_will
-Bryan;0.5;0.5;0.5;0.5;0.5;0.5;0.5;0.5
+;;;;;;;;

--- a/beliefs/currentTrustBelief.csv
+++ b/beliefs/currentTrustBelief.csv
@@ -1,2 +1,2 @@
 name;search_room_comp;search_room_will;obstacle_removal_comp;obstacle_removal_will;search_info_comp;search_info_will;rescue_together_comp;rescue_together_will
-;;;
+Bryan;0.5;0.5;0.5;0.5;0.5;0.5;0.5;0.5


### PR DESCRIPTION
Added the ability to act on the trust to decide if a room should be marked as searched if the human communicates this.

The room will specifically not be added to the searched list when the competence or willingness in the human, corresponding to this task, is below 0.

RescueBot will then inform the human that the room was not added because of their willingness or competence. Rescuebot will also inform them when we do add the room to the searched list.